### PR TITLE
Add x64 build platform

### DIFF
--- a/StringTheory.sln
+++ b/StringTheory.sln
@@ -16,28 +16,28 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Debug|x64.Build.0 = Debug|Any CPU
 		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Debug|x86.Build.0 = Debug|Any CPU
-		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Release|x64.ActiveCfg = Release|Any CPU
+		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Release|x64.Build.0 = Release|Any CPU
 		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Release|x86.ActiveCfg = Release|Any CPU
 		{A249EA9E-F364-459C-A5AB-669F2C7C28AC}.Release|x86.Build.0 = Release|Any CPU
-		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Debug|x86.Build.0 = Debug|Any CPU
-		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Release|x86.ActiveCfg = Release|Any CPU
-		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Release|x86.Build.0 = Release|Any CPU
+		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Debug|x64.ActiveCfg = Debug|x64
+		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Debug|x64.Build.0 = Debug|x64
+		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Debug|x86.ActiveCfg = Debug|x86
+		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Debug|x86.Build.0 = Debug|x86
+		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Release|x64.ActiveCfg = Release|x64
+		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Release|x64.Build.0 = Release|x64
+		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Release|x86.ActiveCfg = Release|x86
+		{11D8BE74-D470-41C0-A53D-29ADB7149D8E}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/StringTheory/StringTheory.csproj
+++ b/StringTheory/StringTheory.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{11D8BE74-D470-41C0-A53D-29ADB7149D8E}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>StringTheory</RootNamespace>
@@ -16,21 +16,40 @@
     <Deterministic>true</Deterministic>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\x86\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\x64\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Adds separate build platforms for x86 and x64. With this change, I can now debug an x64 crash dump (see #19).

I can't successfully open `devenv.dmp` with the x86 build, but that was true for me with v0.1 downloaded from the Releases page. The x86 build can successfully attach to devenv.exe, though.