### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,54 @@
+pool:
+  vmImage: 'VS2017-Win2016'
+
+variables:
+  solution: 'StringTheory.sln'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@0
+
+- task: NuGetCommand@2
+  displayName: 'Restore packages for Microsoft.Diagnostics.Runtime'
+  inputs:
+    command: 'restore'
+    restoreSolution: 'clrmd\Microsoft.Diagnostics.Runtime.sln'
+    feedsToUse: 'config'
+    nugetConfigPath: 'clrmd\NuGet.config'
+
+- task: NuGetCommand@2
+  displayName: 'Restore packages for StringTheory'
+  inputs:
+    command: 'restore'
+    restoreSolution: '$(solution)'
+
+- task: VSBuild@1
+  displayName: 'Build x86 (Release)'
+  inputs:
+    solution: '$(solution)'
+    platform: 'x86'
+    configuration: '$(buildConfiguration)'
+
+- task: CopyFiles@2
+  inputs:
+    sourceFolder: StringTheory\bin\x86\Release
+    contents: '**\!(*.xml)'
+    targetFolder: $(Build.ArtifactStagingDirectory)\x86
+
+- task: VSBuild@1
+  displayName: 'Build x64 (Release)'
+  inputs:
+    solution: '$(solution)'
+    platform: 'x64'
+    configuration: '$(buildConfiguration)'
+
+- task: CopyFiles@2
+  inputs:
+    sourceFolder: StringTheory\bin\x64\Release
+    contents: '**\!(*.xml)'
+    targetFolder: $(Build.ArtifactStagingDirectory)\x64
+
+- task: PublishPipelineArtifact@0
+  inputs:
+    artifactName: 'StringTheory'
+    targetPath: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
On #11, you wrote:

> I'd like to automate production of the release archive, meaning a single script produces both builds.

This adds an automated CI build (using Azure Pipelines) that publishes an artifact containing the x86 and x64 binaries. [Example here](https://dev.azure.com/bgrainger/string-theory/_build/results?buildId=12&view=results); click on "StringTheory" under "Build artifacts published" in "Summary".

To set this up, you'll have to create an Azure DevOps org if you don't have one already, give it permission to access your repo, create a new Pipelines project, and use the `azure-pipelines.yml` from this PR as your pipeline (or as a template for tweaking it).

Note that when creating the Azure Pipeline, you will have to explicitly enable submodule checkout in the Azure UI.

Eventually, you should be able to automatically [create a GitHub release](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azure-devops) with artifacts on some kind of trigger, e.g., tagging the repo.